### PR TITLE
Re-hide selected icons after direct application actions

### DIFF
--- a/OverflowBar/Services/MenuBarItemStore.swift
+++ b/OverflowBar/Services/MenuBarItemStore.swift
@@ -497,6 +497,7 @@ final class MenuBarItemStore: ObservableObject {
         activatingItemID = item.id
         lastActivationError = nil
         if mouseButton == .left, activator.activateDirectly(item) {
+            rehideAfterNextUserClick(item)
             finishActivation()
             return
         }
@@ -522,12 +523,14 @@ final class MenuBarItemStore: ObservableObject {
         // this expensive full-tree walk and use the direct per-process path
         // after their short reveal.
         if mouseButton == .left, item.axElement != nil, activateUsingFreshAccessibility(item) {
+            rehideAfterNextUserClick(item)
             finishActivation()
             return
         }
         if mouseButton == .left,
            item.windowID == nil,
            activator.activateViaAccessibilityHitTest(item) {
+            rehideAfterNextUserClick(item)
             finishActivation()
             return
         }


### PR DESCRIPTION
## What changed

- Schedule the existing re-hide flow after successful direct AXPress activation.
- Cover refreshed Accessibility elements and Accessibility hit-test activation paths.

## Why

When a selected item was activated through one of the direct Accessibility paths, `MenuBarItemStore` cleared the activation state without setting `pendingRehideItem`. The application's menu or popover could open, but after it closed the selected original icon stayed visible in the menu bar.

This keeps the existing delayed menu/popover dismissal checks and only adds the missing handoff to them.

## Validation

- [x] `git diff --check`
- [x] Debug build
- [x] Release build
- [ ] Live menu bar behavior tested on the installed branch build
- [ ] Safe Reset / normal quit restoration tested when layout code changed (layout code unchanged)
- [ ] Documentation updated (internal activation behavior only)

## Environment

- macOS 26 development host
- OverflowBar ad-hoc build, bundle identifier `com.overflowbar.mac26.v6`
- Affected paths: direct Accessibility press, refreshed Accessibility press, and Accessibility hit-test activation

Closes #1
