### PR TITLE
Fix Screen Recording permission request

### DIFF
--- a/OverflowBar/Services/PermissionManager.swift
+++ b/OverflowBar/Services/PermissionManager.swift
@@ -20,15 +20,14 @@ final class PermissionManager: ObservableObject {
     }
 
     func requestScreenRecording() {
-        // Permission state can be stale when a local build replaces the
-        // release identity. Calling CGRequestScreenCaptureAccess repeatedly
-        // in that state reopens the macOS authorization sheet even when
-        // System Settings still shows OverflowBar as allowed. A permission
-        // button must only open the settings pane; capture itself remains
-        // gated by the read-only preflight check in MenuBarCaptureService.
         refresh()
         guard !screenRecordingGranted else { return }
-        openScreenRecordingSettings()
+        // Ask TCC first so supported app identities get the native prompt.
+        // Ad-hoc/background builds may not be promptable on macOS 26; in that
+        // case, open the exact pane so the user can add or enable this build.
+        _ = CGRequestScreenCaptureAccess()
+        refresh()
+        if !screenRecordingGranted { openScreenRecordingSettings() }
     }
 
     func openAccessibilitySettings() { open("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") }


### PR DESCRIPTION
## Summary
- call CGRequestScreenCaptureAccess when the user clicks Request
- refresh the status immediately after the request
- fall back to the Screen & System Audio Recording pane when macOS does not grant immediately (including ad-hoc builds)

## Validation
- xcodebuild Debug: passed
- xcodebuild Release: passed
- universal arm64/x86_64 ad-hoc app installed at /Applications/OverflowBar.app
- physical macOS test: Request completed and Screen Recording became usable after authorization